### PR TITLE
Setup metrics

### DIFF
--- a/sensor_app/docker-compose.yml
+++ b/sensor_app/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - GRPC_VERBOSITY=debug
       - COLLECTOR_ADDRESS=otel-collector
+      - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
     command: src/server.py
 
   grpc-client:
@@ -37,6 +38,7 @@ services:
     environment:
       - GRPC_VERBOSITY=debug
       - COLLECTOR_ADDRESS=otel-collector
+      - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
     command: src/client.py
     deploy:
       replicas: 3

--- a/sensor_app/otel-collector-config.yaml
+++ b/sensor_app/otel-collector-config.yaml
@@ -3,6 +3,8 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:
@@ -11,6 +13,8 @@ extensions:
   health_check: {}
 
 exporters:
+  debug:
+
   otlp:
     endpoint: jaeger:4317
     tls:
@@ -18,6 +22,9 @@ exporters:
 
   prometheus:
     endpoint: 0.0.0.0:9090
+    resource_to_telemetry_conversion:
+      enabled: true
+    enable_open_metrics: true
 
 service:
   pipelines:
@@ -29,4 +36,4 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheus]
+      exporters: [prometheus, debug]

--- a/sensor_app/prometheus.yml
+++ b/sensor_app/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 2s
+  scrape_interval: 1s
 scrape_configs:
   - job_name: "otel-collector"
     static_configs:

--- a/sensor_app/requirements.txt
+++ b/sensor_app/requirements.txt
@@ -1,7 +1,9 @@
 grpcio
 grpcio-tools
+grpcio-observability
 grpcio-health-checking
 opentelemetry-sdk
 opentelemetry-instrumentation-grpc
 opentelemetry-exporter-jaeger
 opentelemetry-exporter-otlp
+protobuf==3.20.3

--- a/sensor_app/src/client.py
+++ b/sensor_app/src/client.py
@@ -57,7 +57,8 @@ if __name__ == "__main__":
     stub = sensor_pb2_grpc.SensorServiceStub(channel)
     metadata = [("authorization", "sensor_token_abc")]
 
-    tracing.setup_tracing('client', __name__)
+    tracing.setup_tracing('client')
+    tracing.setup_metrics('client')
 
     while True:
         choosen_request = random.randint(0, 3)


### PR DESCRIPTION
This PR fixes the way we tried to export metrics from the grpc services and introduces generic metrics provided with the `grpc-observability` package plugin.